### PR TITLE
TS 3.1.0: Use Connection#execute, not #query.

### DIFF
--- a/lib/thinking_sphinx/deltas/sidekiq_delta/flag_as_deleted_job.rb
+++ b/lib/thinking_sphinx/deltas/sidekiq_delta/flag_as_deleted_job.rb
@@ -7,7 +7,7 @@ class ThinkingSphinx::Deltas::SidekiqDelta::FlagAsDeletedJob
 
   def perform(index, document_id)
     ThinkingSphinx::Connection.pool.take do |connection|
-      connection.query(
+      connection.execute(
         Riddle::Query.update(index, document_id, :sphinx_deleted => true)
       )
     end

--- a/ts-sidekiq-delta.gemspec
+++ b/ts-sidekiq-delta.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency 'thinking-sphinx', '>= 3.0.0'
+  s.add_dependency 'thinking-sphinx', '>= 3.1.0'
   s.add_dependency 'sidekiq',         '>= 2.5.4'
 
   s.add_development_dependency 'activerecord',     '>= 3.1.0'


### PR DESCRIPTION
Hi Pat,

we updated to TS 3.1.0 recently and found a little incompatibility with ts-sidekiq-delta. Hope you can integrate this at some point.

Best,
Malte
