### PR TITLE
unique_prefix is now lock_prefix in sidekiq-unique-jobs >=7

### DIFF
--- a/lib/thinking_sphinx/deltas/sidekiq_delta/delta_job.rb
+++ b/lib/thinking_sphinx/deltas/sidekiq_delta/delta_job.rb
@@ -3,7 +3,7 @@
 class ThinkingSphinx::Deltas::SidekiqDelta::DeltaJob
   include Sidekiq::Worker
 
-  sidekiq_options lock: :until_executed, retry: true, queue: 'ts_delta', unique_prefix: 'tsdelta'
+  sidekiq_options lock: :until_executed, retry: true, queue: 'ts_delta', lock_prefix: 'tsdelta'
 
   # Runs Sphinx's indexer tool to process the index.
   #

--- a/lib/thinking_sphinx/deltas/sidekiq_delta/flag_as_deleted_job.rb
+++ b/lib/thinking_sphinx/deltas/sidekiq_delta/flag_as_deleted_job.rb
@@ -3,7 +3,7 @@ class ThinkingSphinx::Deltas::SidekiqDelta::FlagAsDeletedJob
 
   # Runs Sphinx's indexer tool to process the index. Currently assumes Sphinx
   # is running.
-  sidekiq_options lock: :until_executed, retry: true, queue: 'ts_delta', unique_prefix: "tsflagasdeleted"
+  sidekiq_options lock: :until_executed, retry: true, queue: 'ts_delta', lock_prefix: "tsflagasdeleted"
 
   def perform(index, document_id)
     ThinkingSphinx::Deltas::DeleteJob.new(index, document_id).perform

--- a/ts-sidekiq-delta.gemspec
+++ b/ts-sidekiq-delta.gemspec
@@ -1,7 +1,7 @@
 # -*- encoding: utf-8 -*-
 Gem::Specification.new do |s|
   s.name        = 'ts-sidekiq-delta'
-  s.version     = '0.3.0'
+  s.version     = '0.4.0'
   s.platform    = Gem::Platform::RUBY
   s.authors     = ['Pat Allan', 'Aaron Gibralter', 'Danny Hawkins']
   s.email       = ['pat@freelancing-gods.com', 'danny.hawkins@gmail.com']
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'thinking-sphinx',     '>= 3.1.0'
   s.add_dependency 'sidekiq',             '>= 2.5.4'
-  s.add_dependency 'sidekiq-unique-jobs', '>= 6.0.0'
+  s.add_dependency 'sidekiq-unique-jobs', '>= 7.0.0'
 
   s.add_development_dependency 'activerecord',     '>= 3.1.0'
   s.add_development_dependency 'combustion'


### PR DESCRIPTION
@pat `unique_prefix` is now `lock_prefix` on sidekiq-unique-jobs >=7.0.0

This bumps the version requirement on sidekiq-unique-jobs as well, similar to PR #10 