### PR TITLE
Add a lock_ttl to the sidekiq jobs

### DIFF
--- a/lib/thinking_sphinx/deltas/sidekiq_delta/delta_job.rb
+++ b/lib/thinking_sphinx/deltas/sidekiq_delta/delta_job.rb
@@ -3,7 +3,7 @@
 class ThinkingSphinx::Deltas::SidekiqDelta::DeltaJob
   include Sidekiq::Worker
 
-  sidekiq_options lock: :until_executed, retry: true, queue: 'ts_delta', lock_prefix: 'tsdelta'
+  sidekiq_options lock: :until_executed, retry: true, queue: 'ts_delta', lock_prefix: 'tsdelta', lock_ttl: 1.hour.to_i
 
   # Runs Sphinx's indexer tool to process the index.
   #

--- a/lib/thinking_sphinx/deltas/sidekiq_delta/flag_as_deleted_job.rb
+++ b/lib/thinking_sphinx/deltas/sidekiq_delta/flag_as_deleted_job.rb
@@ -3,7 +3,7 @@ class ThinkingSphinx::Deltas::SidekiqDelta::FlagAsDeletedJob
 
   # Runs Sphinx's indexer tool to process the index. Currently assumes Sphinx
   # is running.
-  sidekiq_options lock: :until_executed, retry: true, queue: 'ts_delta', lock_prefix: "tsflagasdeleted"
+  sidekiq_options lock: :until_executed, retry: true, queue: 'ts_delta', lock_prefix: "tsflagasdeleted", lock_ttl: 1.hour.to_i
 
   def perform(index, document_id)
     ThinkingSphinx::Deltas::DeleteJob.new(index, document_id).perform


### PR DESCRIPTION
It's possible that the lock added by sidekiq-unique-jobs is not removed in exceptional scenarios (outage, server reboot, etc.). This prevents any further jobs from processing forever (or at least until the lock is cleared by redis expiry or dev intervention) and silently.

Add a TTL so that in this case, things eventually start processing again. TTL is set to 1 hour, which seems like ample time to run jobs normally, but short enough that updates start working again quickly in the event of a problem.